### PR TITLE
fix: mountFIx fully functional, isolated

### DIFF
--- a/SandBox/headers/nameSpace.h
+++ b/SandBox/headers/nameSpace.h
@@ -1,11 +1,23 @@
 #include <sched.h>      // for clone(), CLONE_* flags
-#include <sys/mount.h>  // for mount()
 #include <unistd.h>     // for execvp()
 #include <signal.h>     // for SIGCHLD
+
 #include <string.h>     // for strerror
+
 #include <stdlib.h>     // for exit
+
 #include <iostream>
-#include <sys/wait.h>
+
+#include <sys/wait.h>   
+#include <sys/mount.h>  // for mount()
+#include <sys/stat.h>   //for mkdir() commands
+
+
+//structure to hold the directory paths
+struct mountDirectory{
+    const char* minimalMount;
+    const char* programToRun;
+};
 
 class sandBox{
     public:
@@ -15,43 +27,46 @@ class sandBox{
             std::cout<<"\npid - > "<<getpid();
             std::cout.flush(); //send print buffer to the terminal immidatly as execel will replace the
             //current execution flow.
+            
+            //casting arguments into class obj;
+            mountDirectory* newMask = static_cast<mountDirectory*>(args);
 
             //Remounting the fileSystem For Process.
             std::cout<<"\nremount the root filesystem (/) as a private mount";
             if(mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL) == -1){
                 //MS_REC | MS_PRIVATE means recursively remount / and all its submounts as private, so mount events won’t propagate to other namespaces.
-                perror("mount");
-                return -1;
+                perror("mount MS_PRIVATE");
+                return 1;
             }
 
             
             //changes the root directory of the process to "mountMask/root"
-            if(chroot("mountMask/root") == -1){
+            if(chroot(newMask->minimalMount) == -1){
                 //For chroot to work, the directory must exist and be a valid root environment
                 //so it will require libraries, /proc, etc.
                 perror("chroot");
-                return -1;
+                return 1;
             }
 
             //change directory to / inside the new root.
             if(chdir("/") == -1){
                 perror("chdir");
-                return -1;
+                return 1;
             }
             
+            //proc mount point before mounting
+            mkdir("/proc", 0555); // Permissions: read/execute for all
+
              //Mounts the proc filesystem inside the new root at /proc
             if(mount("proc", "/proc", "proc", 0, NULL) != 0){
                 perror("mount /proc");
                 return -1;
             }
 
-            //convert arg to valid string path as execl required a char* 
-            const char * path = static_cast<const char*>(args);
-
             //execl is used for executing a program
             //and return -1 if program is fail to run
             //perror() tells the error why the program failed.
-            int returns = execl(path, path, NULL);
+            int returns = execl(newMask->programToRun, newMask->programToRun, NULL);
             perror("execl");
 
             return 1;
@@ -60,7 +75,11 @@ class sandBox{
 
 
         //to create SandBox
-        int createNameSpace(const char* path){
+        int createNameSpace(void* args){
+
+            //converting
+            mountDirectory* newMask = static_cast<mountDirectory*>(args);
+
             //allocating stack.
             #define STACK_SIZE (1024 * 1024) //1024byte = 1 kb -> 1024 * 1024 = 1048576byte = 1024kb = 1MB.
             void* child_stack = malloc(STACK_SIZE);
@@ -68,11 +87,11 @@ class sandBox{
             //CLONE_NEWPID create a new pi for child and sandbox it so it cant see any other process
             //but a real PID is also attached that is visible to Parent process
             //SIGCHILD = is a flag that let Parent recive signal form child Process.
-            int flag = CLONE_NEWPID | SIGCHLD | CLONE_NEWNET | CLONE_NEWUTS;
+            int flag = CLONE_NEWPID | SIGCHLD | CLONE_NEWNET | CLONE_NEWUTS | CLONE_NEWNS;
 
             //pid_t is a signed integer that represent process id in linux and macos
             //clone() returns a real pid for the child process but due to CLONE_NEWPID flag child process only sees it self.
-            pid_t child = clone(runItBoxed, (char*) child_stack + STACK_SIZE, flag, (void*)path);
+            pid_t child = clone(runItBoxed, (char*) child_stack + STACK_SIZE, flag, newMask);
             std::cout<<"\nchild pid -> "<<child;
 
             if(child == -1){
@@ -108,6 +127,8 @@ class sandBox{
                 waitpid(child, NULL, 0);
                 return 1;
             }
+
+            waitpid(child, NULL, 0);
             return 0;            
         }
 

--- a/src/WHITE.cpp
+++ b/src/WHITE.cpp
@@ -132,8 +132,11 @@ int main(){
   installPreRequisite();
   std::cout.flush();
 
-  //Boot Check
-  fs::path bootDirectory = fs::path(getPath())/"mountMask";
+  //Boot Check and creation minimal boot.
+  std::string directory = getPath()+"/mountMask";
+  fs::path bootDirectory = fs::path(directory);
+
+  std::cerr<<"using boot from ->"<<bootDirectory;
   try{
     setupDirectoryAndDebootstrap(bootDirectory);
   }
@@ -145,7 +148,15 @@ int main(){
 
   sandBox process;
   std::string path = "/bin/bash";
-  process.createNameSpace(path.c_str());
+
+  //storing paths
+  mountDirectory newDirectories;
+  newDirectories.minimalMount = directory.c_str();
+  newDirectories.programToRun = path.c_str();
+
+
+  //creating isolated process
+  process.createNameSpace(&newDirectories);
   return 0;
 }
 


### PR DESCRIPTION
## Fixed: mount error with /proc and isolation issue
>isolation issue -> **`CLONE_NEWNS`**
>mount issue -> mkdir("/proc", 0555); 
> >mount("proc", "/proc", "proc", 0, NULL);
